### PR TITLE
fix DOCREF for PARENT-REFs using implicit document fragments

### DIFF
--- a/odxtools/templates/macros/printParentRef.xml.jinja2
+++ b/odxtools/templates/macros/printParentRef.xml.jinja2
@@ -5,8 +5,10 @@
 
 {%- macro printParentRef(par) -%}
 <PARENT-REF ID-REF="{{par.layer.odx_id.local_id}}"
-            DOCREF="{{get_parent_container_name(par.layer.short_name)}}"
+{%- if par.layer_ref.ref_docs|length == 1 %}
+            DOCREF="{{par.layer_ref.ref_docs[0].doc_name}}"
             DOCTYPE="CONTAINER"
+{%- endif %}
             xsi:type="{{par.layer.variant_type.value}}-REF">
 {%- if par.not_inherited_diag_comms %}
  <NOT-INHERITED-DIAG-COMMS>

--- a/odxtools/writepdxfile.py
+++ b/odxtools/writepdxfile.py
@@ -21,24 +21,6 @@ def jinja2_odxraise_helper(msg: str) -> None:
     raise Exception(msg)
 
 
-def get_parent_container_name(dl_short_name: str) -> str:
-    """
-    Given the short name of a diagnostic layer, return the name of a container
-    which the layer is part of.
-
-    If no such container exists, a `RuntimeException` is thrown.
-    """
-
-    assert odxdatabase is not None
-
-    for dlc in odxdatabase.diag_layer_containers:
-        if dl_short_name in [dl.short_name for dl in dlc.diag_layers]:
-            return dlc.short_name
-
-    raise RuntimeError(f"get_parent_container_name() could not determine a "
-                       f"container for diagnostic layer '{dl_short_name}'.")
-
-
 def make_xml_attrib(attrib_name: str, attrib_val: Any | None) -> str:
     if attrib_val is None:
         return ""
@@ -145,7 +127,6 @@ def write_pdx_file(
         jinja_env.globals["odxraise"] = jinja2_odxraise_helper
         jinja_env.globals["make_xml_attrib"] = make_xml_attrib
         jinja_env.globals["make_bool_xml_attrib"] = make_bool_xml_attrib
-        jinja_env.globals["get_parent_container_name"] = get_parent_container_name
 
         vars: dict[str, Any] = {}
         vars["odxtools_version"] = odxtools.__version__

--- a/tests/test_compu_methods.py
+++ b/tests/test_compu_methods.py
@@ -27,8 +27,7 @@ from odxtools.odxdoccontext import OdxDocContext
 from odxtools.odxlink import DocType, OdxDocFragment
 from odxtools.odxtypes import DataType
 from odxtools.progcode import ProgCode
-from odxtools.writepdxfile import (get_parent_container_name, jinja2_odxraise_helper,
-                                   make_bool_xml_attrib, make_xml_attrib)
+from odxtools.writepdxfile import jinja2_odxraise_helper, make_bool_xml_attrib, make_xml_attrib
 
 doc_frags = (OdxDocFragment("UnitTest", DocType.CONTAINER),)
 
@@ -50,7 +49,6 @@ class TestLinearCompuMethod(unittest.TestCase):
             jinja_env.globals["odxraise"] = jinja2_odxraise_helper
             jinja_env.globals["make_xml_attrib"] = make_xml_attrib
             jinja_env.globals["make_bool_xml_attrib"] = make_bool_xml_attrib
-            jinja_env.globals["get_parent_container_name"] = get_parent_container_name
 
             return jinja_env
 


### PR DESCRIPTION
I don't know why this blew up my smoke testing script only now. Anyway, the new solution is a bit more generic because it does not need the hacky `get_parent_layer()` function. On the flipside detecting if DOCREF is needed only works for references that feature at least two local document fragments (i.e., which are contained in a DIAG-LAYER).

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbitionio/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 
